### PR TITLE
Fix repository definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/AtomLinter/linter-htmllint"
+    "url": "https://github.com/AtomLinter/linter-htmllint.git"
   },
   "engines": {
     "atom": ">=1.4.0 <2.0.0"


### PR DESCRIPTION
The repository definition was missing `.git` on the end, leading to some git clients having issues recognizing it as a repository.

Fixes #4.