### PR TITLE
Upgrade to linter API v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,7 @@ export default {
       name: 'htmllint',
       grammarScopes: this.grammarScopes,
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: async (editor) => {
         if (!atom.workspace.isTextEditor(editor)) {
           return null;
@@ -145,10 +145,12 @@ export default {
         return issues.map((issue) => {
           try {
             return {
-              range: generateRange(editor, issue.line - 1, issue.column - 1),
-              type: 'error',
-              text: htmllint.messages.renderIssue(issue),
-              filePath
+              severity: 'error',
+              excerpt: htmllint.messages.renderIssue(issue),
+              location: {
+                file: filePath,
+                position: generateRange(editor, issue.line - 1, issue.column - 1)
+              }
             };
           } catch (error) {
             report(issue, error);

--- a/package.json
+++ b/package.json
@@ -92,12 +92,12 @@
     }
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-htmllint-spec.js
+++ b/spec/linter-htmllint-spec.js
@@ -21,10 +21,10 @@ describe('The htmllint provider for Linter', () => {
     const messages = await lint(editor);
 
     expect(messages.length).toEqual(1);
-    expect(messages[0].type).toBe('error');
-    expect(messages[0].text).toBe('<!DOCTYPE> should be the first element seen');
-    expect(messages[0].filePath).toBe(badFile);
-    expect(messages[0].range).toEqual([[0, 0], [0, 5]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].excerpt).toBe('<!DOCTYPE> should be the first element seen');
+    expect(messages[0].location.file).toBe(badFile);
+    expect(messages[0].location.position).toEqual([[0, 0], [0, 5]]);
   });
 
   it('finds nothing wrong with a valid file (good.html)', async () => {


### PR DESCRIPTION
Upgrade this provider to the v2 linter API so it can continue to work with newer versions of `linter`.

Fixes #7.